### PR TITLE
Option to hide footprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added an option to hide footprints (geometry/bounding box) by default
 - Added support for image formats in WMS and WMTS
 - Expose `SourceType` as public API
 - Removed note about Firefox issues in the examples

--- a/examples/stac-collection-pmtiles-vector.js
+++ b/examples/stac-collection-pmtiles-vector.js
@@ -10,6 +10,7 @@ register(proj4); // required to support source reprojection
 
 const layer = new STAC({
   displayWebMapLink: 'pmtiles',
+  displayFootprint: false,
   data: {
     'stac_version': '1.0.0',
     'stac_extensions': [


### PR DESCRIPTION
Implements #9

Hides the footprint layer by default.
Doesn't remove the layers so users could opt to show it again. 
I can't easily remove the layer as it's required to make the fit to bounds functionality work.

@silvestro1