### PR TITLE
Allow links to be selected by id property #12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow a list of web map links to be shown through the `displayWebMapLink` option,
+  which includes selecting links by id.
+
 ## [1.0.0-beta.8] - 2024-01-30
 
 - Fixes the broken 1.0.0-beta.7 release


### PR DESCRIPTION
Allow a list of web map links to be shown through the `displayWebMapLinks` option, which includes selecting links by id.

Implements #12

Please review @silvestro1