### PR TITLE
Set styles to empty array by default

### DIFF
--- a/src/ol/layer/STAC.js
+++ b/src/ol/layer/STAC.js
@@ -504,7 +504,7 @@ class STACLayer extends LayerGroup {
         }
         for (const i in link['wms:layers']) {
           const layers = link['wms:layers'][i];
-          let styles;
+          let styles = [''];
           if (
             Array.isArray(link['wms:styles']) &&
             typeof link['wms:styles'][i] === 'string'


### PR DESCRIPTION
According to https://github.com/stac-extensions/web-map-links, the `wms:styles` should be an array of strings. This PR adds a default fallback in case no styles are specified.