### PR TITLE
propagate useTileLayerAsFallback and buildTileUrlTemplate options

### DIFF
--- a/src/ol/layer/STAC.js
+++ b/src/ol/layer/STAC.js
@@ -685,10 +685,6 @@ class STACLayer extends LayerGroup {
    * @private
    */
   async addGeoTiff_(asset) {
-    if (this.buildTileUrlTemplate_ && !this.useTileLayerAsFallback_) {
-      return await this.addTileLayerForImagery_(asset);
-    }
-
     const sourceInfo = getGeoTiffSourceInfoFromAsset(asset, this.bands_);
 
     /**
@@ -710,6 +706,10 @@ class STACLayer extends LayerGroup {
         options,
         asset
       );
+    }
+
+    if (this.buildTileUrlTemplate_ && !this.useTileLayerAsFallback_) {
+      return await this.addTileLayerForImagery_(asset);
     }
 
     const source = new GeoTIFF(options);

--- a/src/ol/layer/STAC.js
+++ b/src/ol/layer/STAC.js
@@ -482,6 +482,8 @@ class STACLayer extends LayerGroup {
         displayOverview: this.displayOverview_,
         displayPreview: this.displayPreview_,
         displayFootprint: this.displayFootprint_,
+        useTileLayerAsFallback: this.useTileLayerAsFallback_,
+        buildTileUrlTemplate: this.buildTileUrlTemplate_,
       };
       const subgroup = new STACLayer(Object.assign(defaultOptions, options));
       // If no data is given, but items are provided, then we don't get a map from the

--- a/src/ol/layer/STAC.js
+++ b/src/ol/layer/STAC.js
@@ -685,6 +685,10 @@ class STACLayer extends LayerGroup {
    * @private
    */
   async addGeoTiff_(asset) {
+    if (this.buildTileUrlTemplate_ && !this.useTileLayerAsFallback_) {
+      return await this.addTileLayerForImagery_(asset);
+    }
+
     const sourceInfo = getGeoTiffSourceInfoFromAsset(asset, this.bands_);
 
     /**
@@ -706,10 +710,6 @@ class STACLayer extends LayerGroup {
         options,
         asset
       );
-    }
-
-    if (this.buildTileUrlTemplate_ && !this.useTileLayerAsFallback_) {
-      return await this.addTileLayerForImagery_(asset);
     }
 
     const source = new GeoTIFF(options);


### PR DESCRIPTION
as commented in https://github.com/radiantearth/stac-browser/pull/535#issuecomment-2654317862 tile server is not used because some stac-btroser options are not propagated when creating STACLayer childs.

This PR would fix this issue.