### PR TITLE
Header-based auth for more sources, add related options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add `getLayerOptions` option to customize the options of the individual layers that are
-  created for assets and links, e.g. to apply a style to a GeoTIFF or GeoZarr layer.
+### Added
+
+- Add `getLayerOptions` option to customize the options of the individual layers that are created for assets and links, e.g. to apply a style to a GeoTIFF or GeoZarr layer.
   The function can be asynchronous and only delays the creation of the individual layer.
-- Add example for computing an NDVI visualization for a GeoZarr datacube via `getLayerOptions`
+- Add examples for computing an NDVI visualization for a GeoZarr datacube via `getLayerOptions` and header-based authentication
+- Add `getRequestHeaders` option to attach HTTP headers (e.g. for authentication) to the requests made by the layer.
+  Errors from image/tile requests with headers are reported through the layer's `error` event.
+- Add `getRequestUrl` option to rewrite URLs before requests are made or sources are created, e.g. to append query parameters for authentication.
+
+### Changed
+
+- The TileJSON manifest is loaded through the new request function and passed to the source, unless the `jsonp` or `tileJSON` source options are set.
+- `getSourceOptions` is called with `SourceType.PMTiles` before the PMTiles tile type is sniffed, so that URL
+  rewrites (e.g. signed URLs) apply to all PMTiles requests.
+- The default `httpRequestFn` passes the STAC Asset or Link a request is made for to `getRequestHeaders`;
+  custom `httpRequestFn` implementations receive it as an optional third parameter.
+
+### Deprecated
+
+- `SourceType.PMTilesRaster` and `SourceType.PMTilesVector` — use `SourceType.PMTiles` instead.
+  Callbacks that leave the options unchanged for `SourceType.PMTiles` are still called with the
+  deprecated values after the tile type is known; this fallback will be removed in 2.0.0.
+
+### Fixes
+
 - Fix the automatic projection lookup
 - Fix antimeridian handling, which resulted in polygons not showing in certain cases
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,6 +64,7 @@ export default [
         disposeMap: 'readonly',
         it: 'readonly',
         render: 'readonly',
+        sinon: 'readonly',
         where: 'readonly',
       },
     },

--- a/examples/auth-headers.html
+++ b/examples/auth-headers.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: Authentication with HTTP headers
+title: HTTP header authentication
 shortdesc: Rendering a STAC Item that requires HTTP header authentication.
 docs: >
   This example uses the `getRequestHeaders` option to attach an `Authorization`
@@ -10,6 +10,8 @@ docs: >
   hosts. To add credentials via query parameters (e.g. API keys) use the
   `getRequestUrl` option instead. For more complex per-source URL signing,
   see the Planetary Computer example (`getSourceOptions`).
+  **This example shows code only:** there is no public STAC endpoint with
+  header-based authentication, so no map is shown. Replace the host, URL and
+  token in the code below with a protected STAC endpoint of yours.
 tags: "stac, stac item, authentication, authorization, http headers, token"
 ---
-<div id="map" class="map"></div>

--- a/examples/auth-headers.html
+++ b/examples/auth-headers.html
@@ -1,0 +1,15 @@
+---
+layout: example.html
+title: Authentication with HTTP headers
+shortdesc: Rendering a STAC Item that requires HTTP header authentication.
+docs: >
+  This example uses the `getRequestHeaders` option to attach an `Authorization`
+  header to the requests made by the STAC layer: the STAC document itself,
+  GeoTIFF/GeoZarr/PMTiles requests, preview images and map tiles.
+  The callback is invoked per URL so that credentials are only sent to trusted
+  hosts. To add credentials via query parameters (e.g. API keys) use the
+  `getRequestUrl` option instead. For more complex per-source URL signing,
+  see the Planetary Computer example (`getSourceOptions`).
+tags: "stac, stac item, authentication, authorization, http headers, token"
+---
+<div id="map" class="map"></div>

--- a/examples/auth-headers.js
+++ b/examples/auth-headers.js
@@ -9,8 +9,9 @@ import STAC from '../src/ol/layer/STAC.js';
 register(proj4);
 
 // There is no public STAC endpoint with header-based authentication, so this
-// example can't render anything as-is. Replace the host, URL and token below
-// with a protected STAC endpoint of yours to see it in action.
+// example shows the code only and doesn't render a map. To see it in action,
+// replace the host, URL and token below with a protected STAC endpoint of
+// yours and add a `<div id="map" class="map"></div>` to the page.
 
 // The hosts that may receive the credentials.
 const trustedHosts = ['example.com'];

--- a/examples/auth-headers.js
+++ b/examples/auth-headers.js
@@ -1,0 +1,53 @@
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/WebGLTile.js';
+import {register} from 'ol/proj/proj4.js';
+import OSM from 'ol/source/OSM.js';
+import proj4 from 'proj4';
+import STAC from '../src/ol/layer/STAC.js';
+
+register(proj4);
+
+// There is no public STAC endpoint with header-based authentication, so this
+// example can't render anything as-is. Replace the host, URL and token below
+// with a protected STAC endpoint of yours to see it in action.
+
+// The hosts that may receive the credentials.
+const trustedHosts = ['example.com'];
+
+const layer = new STAC({
+  url: 'https://example.com/stac/item.json',
+  getRequestHeaders(ref, url) {
+    // Only send the credentials to trusted hosts, asset and tile URLs
+    // may point elsewhere.
+    if (!trustedHosts.includes(new URL(url).host)) {
+      return null;
+    }
+    return {
+      Authorization: 'Bearer get_your_own_token',
+    };
+  },
+});
+
+const background = new TileLayer({
+  source: new OSM(),
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [background, layer],
+  view: new View({
+    center: [0, 0],
+    zoom: 0,
+  }),
+});
+
+layer.on('sourceready', () => {
+  const view = map.getView();
+  view.fit(layer.getExtent());
+});
+
+layer.on('error', (event) => {
+  // Failed requests (e.g. expired credentials) are reported here.
+  console.error(event.error); // eslint-disable-line no-console
+});

--- a/examples/custom.html
+++ b/examples/custom.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: Custom STAC provided via URL
+title: "- Custom STAC provided via URL -"
 shortdesc: Rendering a STAC entity as a layer.
 docs: >
   Provide your own STAC entity and see it rendered as a layer on the map.

--- a/examples/stac-collection-pmtiles-raster.html
+++ b/examples/stac-collection-pmtiles-raster.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Collection with PMTiles (Raster)
+title: PMTiles (Raster) visualization in a STAC Collection
 shortdesc: Rendering a STAC Collection with a selection of web mapping services.
 docs: >
   Geometry and web map links (PMTiles) from SpatioTemporal Asset Catalog (STAC) Collections can be rendered as layer group.

--- a/examples/stac-collection-pmtiles-vector.html
+++ b/examples/stac-collection-pmtiles-vector.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Collection with PMTiles (Vector)
+title: PMTiles (Vector) visualization in a STAC Collection
 shortdesc: Rendering a STAC Collection with a selection of web mapping services.
 docs: >
   Geometry and web map links (PMTiles) from SpatioTemporal Asset Catalog (STAC) Collections can be rendered as layer group.

--- a/examples/stac-collection-pmtiles-vector.js
+++ b/examples/stac-collection-pmtiles-vector.js
@@ -2,38 +2,51 @@ import Map from 'ol/Map.js';
 import View from 'ol/View.js';
 import TileLayer from 'ol/layer/WebGLTile.js';
 import {register} from 'ol/proj/proj4.js';
+import {fromLonLat} from 'ol/proj.js';
 import OSM from 'ol/source/OSM.js';
+import {Fill, Stroke, Style} from 'ol/style.js';
 import proj4 from 'proj4';
 import STAC from '../src/ol/layer/STAC.js';
+import LayerType from '../src/ol/layer/type.js';
 
 register(proj4); // required to support source reprojection
 
 const layer = new STAC({
   displayWebMapLink: 'pmtiles',
   displayFootprint: false,
+  // Add a custom style for the buildings
+  getLayerOptions(type, options) {
+    if (type === LayerType.VectorTile) {
+      options.style = new Style({
+        fill: new Fill({color: 'rgba(255, 0, 0, 0.8)'}),
+        stroke: new Stroke({color: '#990000', width: 1}),
+      });
+    }
+    return options;
+  },
   data: {
     'stac_version': '1.1.0',
     'stac_extensions': [
       'https://stac-extensions.github.io/web-map-links/v1.2.0/schema.json',
     ],
     'type': 'Collection',
-    'id': 'Overtuere Maps Buildings',
+    'id': 'Overture Maps Buildings',
     'description':
-      'The Overture Maps buildings theme describes human-made structures with roofs or interior spaces that are permanently or semi-permanently in one place.',
+      'The Overture Maps buildings theme describes human-made structures with roofs or interior spaces that are permanently or semi-permanently in one place. Hosted on Source Cooperative.',
     'license': 'ODbL',
     'attribution': '© Overture Maps Foundation',
     'extent': {
       'spatial': {
-        'bbox': [[-180, -90, 180, 90]],
+        'bbox': [[-180, -83.66, 180, 82.53]],
       },
       'temporal': {
-        'interval': [['2025-04-23T00:00:00Z', '2025-04-24T00:00:00Z']],
+        'interval': [['2023-07-26T00:00:00Z', null]],
       },
     },
     'links': [
       {
         'href':
-          'https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2025-04-23/places.pmtiles',
+          'https://data.source.coop/cholmes/overture/overture-buildings.pmtiles',
         'rel': 'pmtiles',
         'type': 'application/vnd.pmtiles',
         'title': 'Buildings',
@@ -50,11 +63,8 @@ const map = new Map({
   target: 'map',
   layers: [background, layer],
   view: new View({
-    center: [0, 0],
-    zoom: 0,
+    // Zoom to a specific location to visualize the buildings
+    center: fromLonLat([7.6261, 51.9607]),
+    zoom: 15,
   }),
-});
-layer.on('sourceready', () => {
-  const view = map.getView();
-  view.fit(layer.getExtent());
 });

--- a/examples/stac-collection-with-items.html
+++ b/examples/stac-collection-with-items.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Collection with child items
+title: Collection with child items
 shortdesc: Rendering a STAC Collection with its child items
 docs: >
   Geometries and Thumbnails for various SpatioTemporal Asset Catalog (STAC) Items in an ItemCollection can be rendered as part of its parent collection.

--- a/examples/stac-collection-wms.html
+++ b/examples/stac-collection-wms.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Collection with WMS
+title: WMS visualization in a STAC Collection
 shortdesc: Rendering a STAC Collection with a selection of web mapping services.
 docs: >
   Geometry and web map links (WMS) from SpatioTemporal Asset Catalog (STAC) Collections can be rendered as layer group.

--- a/examples/stac-item-antimeridian.html
+++ b/examples/stac-item-antimeridian.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item crossing the antimeridian
+title: Geometries crossing the antimeridian
 shortdesc: Rendering a STAC Item whose geometry crosses the antimeridian (180° longitude).
 docs: >
   The footprint of this STAC Item crosses the antimeridian (180° longitude).

--- a/examples/stac-item-classification.html
+++ b/examples/stac-item-classification.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item with Classification
+title: Classification layer visualization in a STAC Item
 shortdesc: Rendering a STAC Item with a Scene Classification Layer with corresponding coloring.
 docs: >
   Geometry and Assets from SpatioTemporal Asset Catalog (STAC) Items with classification can be rendered as layer group.

--- a/examples/stac-item-from-object.html
+++ b/examples/stac-item-from-object.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item from an object
+title: JavaScript object directly embedded
 shortdesc: Rendering a STAC Item as a layer that is provided as a JS object.
 docs: >
   Geometry and Assets from SpatioTemporal Asset Catalog (STAC) Items can be rendered as layer group.

--- a/examples/stac-item-geojson.html
+++ b/examples/stac-item-geojson.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item with GeoJSON assets
+title: GeoJSON asset visualization in a STAC Item
 shortdesc: Rendering a STAC Item with two GeoJSON assets
 docs: >
   Geometry and GeoJSON Assets from SpatioTemporal Asset Catalog (STAC) Items can be rendered as layer group.

--- a/examples/stac-item-labels.html
+++ b/examples/stac-item-labels.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item with Label Extension
+title: Label Extension support in a STAC Item
 shortdesc: Rendering a STAC Item with labels and source imagery
 docs: >
   SpatioTemporal Asset Catalog (STAC) Items with the label extension can show additional information.

--- a/examples/stac-item-tileserver.html
+++ b/examples/stac-item-tileserver.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item with COG rendered by a tile server
+title: COGs rendered by a tile server in a STAC Item
 shortdesc: Rendering a STAC Item as a layer, but uses a tile server instead of client-side GeoTiff rendering.
 docs: >
   Geometry and Assets from SpatioTemporal Asset Catalog (STAC) Items can be rendered as layer group using a tile server.

--- a/examples/stac-item-zarr.html
+++ b/examples/stac-item-zarr.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item with GeoZarr asset
+title: GeoZarr visualization in a STAC Item
 shortdesc: Rendering a STAC Item with Web-Optimized GeoZarr assets
 docs: >
   Visualize Web-Optimized GeoZarr assets from SpatioTemporal Asset Catalog (STAC) Items.

--- a/examples/stac-item.html
+++ b/examples/stac-item.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item
+title: Basic STAC Item visualization
 shortdesc: Rendering a STAC Item as a layer.
 docs: >
   Geometry and Assets from SpatioTemporal Asset Catalog (STAC) Items can be rendered as layer group.

--- a/examples/stac-itemcollection.html
+++ b/examples/stac-itemcollection.html
@@ -1,6 +1,6 @@
 ---
 layout: example.html
-title: STAC Item Collection
+title: Displaying multiple Items from a Item Collection
 shortdesc: Rendering a STAC Item Collection as a layer.
 docs: >
   Geometries and Thumbnails for various SpatioTemporal Asset Catalog (STAC) Items in an ItemCollection can be rendered as layer group.

--- a/src/ol/http.js
+++ b/src/ol/http.js
@@ -1,0 +1,109 @@
+/**
+ * @module ol/http
+ */
+
+/**
+ * A function that returns the HTTP headers to send for the given URL,
+ * or `null` if no additional headers should be sent.
+ * @typedef {function(string): (Object<string, string>|null)} GetHeadersFn
+ */
+
+/**
+ * A function that is called when a request has failed.
+ * @typedef {function(Error): void} OnErrorFn
+ */
+
+/**
+ * Checks whether the given headers are a non-empty object.
+ * @param {*} headers The headers to check.
+ * @return {boolean} `true` if there's at least one header, `false` otherwise.
+ */
+function hasHeaders(headers) {
+  return (
+    typeof headers === 'object' &&
+    headers !== null &&
+    Object.keys(headers).length > 0
+  );
+}
+
+/**
+ * Loads the given source into the image element.
+ *
+ * If headers are returned for the source URL, the source is requested
+ * through the Fetch API with the headers attached and the response is
+ * assigned to the image element as an object URL, which is revoked once
+ * the image has loaded. Otherwise, the source is assigned directly.
+ *
+ * On request failure, the error is reported and the source is assigned
+ * directly as a fallback, so that errors are reported through the image
+ * element as usual.
+ *
+ * @param {HTMLImageElement} img The image element to load the source into.
+ * @param {string} src The source URL.
+ * @param {GetHeadersFn} getHeaders Returns the headers to send for a URL.
+ * @param {OnErrorFn|null} onError Called when the request failed.
+ */
+function load(img, src, getHeaders, onError) {
+  const headers = getHeaders(src);
+  if (!hasHeaders(headers)) {
+    img.src = src;
+    return;
+  }
+  fetch(src, {headers})
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Unexpected response from ${src}: ${response.status}`);
+      }
+      return response.blob();
+    })
+    .then((blob) => {
+      const objectUrl = URL.createObjectURL(blob);
+      const revoke = () => URL.revokeObjectURL(objectUrl);
+      img.addEventListener('load', revoke, {once: true});
+      img.addEventListener('error', revoke, {once: true});
+      img.src = objectUrl;
+    })
+    .catch((error) => {
+      if (onError) {
+        onError(error);
+      }
+      img.src = src;
+    });
+}
+
+/**
+ * Creates an `imageLoadFunction` (e.g. for `ol/source/ImageStatic`) that
+ * attaches the headers returned by the given function to the image requests.
+ * See {@link module:ol/http~load} for details.
+ *
+ * @param {GetHeadersFn} getHeaders Returns the headers to send for a URL.
+ * @param {OnErrorFn|null} [onError] Called when a request failed.
+ * @return {function(import('ol/Image.js').default, string): void} The image load function.
+ * @api
+ */
+export function createImageLoadFunction(getHeaders, onError = null) {
+  return (image, src) => {
+    const img = /** @type {HTMLImageElement} */ (image.getImage());
+    load(img, src, getHeaders, onError);
+  };
+}
+
+/**
+ * Creates a `tileLoadFunction` for image tile sources (e.g. `ol/source/XYZ`)
+ * that attaches the headers returned by the given function to the tile
+ * requests. The headers are requested per tile URL.
+ * See {@link module:ol/http~load} for details.
+ *
+ * @param {GetHeadersFn} getHeaders Returns the headers to send for a URL.
+ * @param {OnErrorFn|null} [onError] Called when a request failed.
+ * @return {function(import('ol/Tile.js').default, string): void} The tile load function.
+ * @api
+ */
+export function createTileLoadFunction(getHeaders, onError = null) {
+  return (tile, src) => {
+    const img = /** @type {HTMLImageElement} */ (
+      /** @type {import('ol/ImageTile.js').default} */ (tile).getImage()
+    );
+    load(img, src, getHeaders, onError);
+  };
+}

--- a/src/ol/layer/STAC.js
+++ b/src/ol/layer/STAC.js
@@ -29,6 +29,7 @@ import {
 } from 'stac-js/src/mediatypes.js';
 import {isObject} from 'stac-js/src/utils.js';
 import ErrorEvent from '../events/ErrorEvent.js';
+import {createImageLoadFunction, createTileLoadFunction} from '../http.js';
 import {getProjection} from '../proj.js';
 import SourceType from '../source/type.js';
 import {
@@ -75,6 +76,15 @@ import LayerType from './type.js';
 /**
  * @typedef {import('./type.js').LayerOptions} LayerOptions
  */
+/**
+ * @typedef {import('../http.js').GetHeadersFn} GetHeadersFn
+ */
+/**
+ * @typedef {import('../http.js').OnErrorFn} OnErrorFn
+ */
+/**
+ * @typedef {function((import("ol/Image.js").default|import("ol/Tile.js").default), string): void} LoadFunction
+ */
 
 /**
  * @typedef {Object} Options
@@ -96,8 +106,9 @@ import LayerType from './type.js';
  * Optional function that can be used to configure the underlying sources. The function can do any additional work
  * and return the completed options or a promise for the same. The function will be called with the current source options
  * and the STAC Asset or Link.
- * This can be useful for adding auth information such as an API token, either via query parameter or HTTP headers.
- * Please be aware that sending HTTP headers may not be supported by all sources.
+ * This can be useful for advanced per-source customization such as signed URLs.
+ * To add credentials via query parameters, use the `getRequestUrl` option instead;
+ * to send credentials via HTTP headers, use the `getRequestHeaders` option instead.
  * @property {function(LayerType, LayerOptions, (Asset|Link)):(LayerOptions|Promise<LayerOptions>)} [getLayerOptions]
  * Optional function that can be used to configure the individual layers that are created for the assets and links.
  * The function can do any additional (asynchronous) work and return the completed options or a promise for the same.
@@ -153,6 +164,22 @@ import LayerType from './type.js';
  * @property {function(string,string):(*)} [httpRequestFn=null] Sets a custom function to make HTTP requests with.
  * The first parameter is the URL to request and the output is a promise that resolves with the response body.
  * The second parameter is the return type, either `json` (default) or `text`.
+ * The STAC Asset or Link the request is made for is passed as third parameter, if available.
+ * @property {Object<string, string>|function((Asset|Link|STACObject|null), string):(Object<string, string>|null)} [getRequestHeaders=null]
+ * The HTTP headers (e.g. for authentication) to send with the requests made by this layer,
+ * either as a plain object or as a function that returns the headers (or `null` for none) and
+ * is called with the STAC Asset or Link that is shown (if available) and the URL that is requested.
+ * Use a function to restrict the headers to specific hosts, as tile server URLs and asset URLs
+ * may point to hosts that should not receive the credentials.
+ * The headers are attached to requests made by the default `httpRequestFn`, to GeoTIFF, GeoZarr
+ * and PMTiles requests, and via image/tile load functions (through the Fetch API and object URLs)
+ * to preview images and XYZ, TileJSON, WMS and WMTS tiles.
+ * @property {function((Asset|Link|STACObject|null), string):(string|null)} [getRequestUrl=null]
+ * Rewrites a URL before a request is made or a source is created, e.g. to append query
+ * parameters for authentication (signed URLs, API keys). The function is called with the
+ * STAC Asset or Link that is shown (if available) and the URL, and returns the new URL or
+ * `null` to keep the URL unchanged. The rewrite is applied before `getSourceOptions` is called.
+ * For tiled sources the tile URL template is rewritten, not the individual tile URLs.
  */
 
 /**
@@ -197,6 +224,18 @@ class STACLayer extends LayerGroup {
      * @private
      */
     this.getLayerOptions_ = options.getLayerOptions;
+
+    /**
+     * @type {Object<string, string>|function((Asset|Link|STACObject|null), string):(Object<string, string>|null)|null}
+     * @private
+     */
+    this.getRequestHeaders_ = options.getRequestHeaders || null;
+
+    /**
+     * @type {function((Asset|Link|STACObject|null), string):(string|null)|null}
+     * @private
+     */
+    this.getRequestUrl_ = options.getRequestUrl || null;
 
     /**
      * @type {Array<STAC>|null}
@@ -334,7 +373,7 @@ class STACLayer extends LayerGroup {
       throw new Error('Either url or data must be provided');
     }
 
-    this.fetch_(options.url)
+    this.fetch_(this.getRequestUrlFor_(options.url))
       .then((data) =>
         this.configure_(
           data,
@@ -348,14 +387,71 @@ class STACLayer extends LayerGroup {
   }
 
   /**
+   * Rewrites the given URL based on the `getRequestUrl` option.
+   *
+   * @param {string} url The URL that is requested.
+   * @param {Asset|Link|STACObject|null} [ref] The STAC Asset or Link that is shown, if available.
+   * @return {string} The rewritten URL, or the given URL if it is not rewritten.
+   */
+  getRequestUrlFor_(url, ref = null) {
+    if (typeof this.getRequestUrl_ === 'function' && typeof url === 'string') {
+      const newUrl = this.getRequestUrl_(ref, url);
+      if (typeof newUrl === 'string' && newUrl.length > 0) {
+        return newUrl;
+      }
+    }
+    return url;
+  }
+
+  /**
+   * Returns the HTTP headers to send for the given URL, based on the
+   * `getRequestHeaders` option.
+   *
+   * @param {string} url The URL that is requested.
+   * @param {Asset|Link|STACObject|null} [ref] The STAC Asset or Link that is shown, if available.
+   * @return {Object<string, string>|null} The headers, or `null` if there are none.
+   */
+  getRequestHeadersFor_(url, ref = null) {
+    let headers = this.getRequestHeaders_;
+    if (typeof headers === 'function') {
+      headers = headers(ref, url);
+    }
+    if (isObject(headers) && Object.keys(headers).length > 0) {
+      return /** @type {Object<string, string>} */ (headers);
+    }
+    return null;
+  }
+
+  /**
+   * Creates a load function for images or tiles that attaches the headers
+   * from the `getRequestHeaders` option and reports errors through the
+   * layer's error event, or `undefined` if no headers are configured.
+   *
+   * @param {function(GetHeadersFn, OnErrorFn=):LoadFunction} factory `createImageLoadFunction` or `createTileLoadFunction`.
+   * @param {Asset|Link|STACObject|null} ref The STAC Asset or Link that is shown, if available.
+   * @return {LoadFunction|undefined} The load function.
+   */
+  createLoadFunction_(factory, ref) {
+    if (!this.getRequestHeaders_) {
+      return undefined;
+    }
+    return factory(
+      (url) => this.getRequestHeadersFor_(url, ref),
+      (error) => this.handleError_(error),
+    );
+  }
+
+  /**
    * Default function make HTTP requests with.
    *
    * @param {string} url The URL to request and the output is a promise that resolves with the response body.
    * @param {string} responseType The return type, either `json` (default) or `text`.
+   * @param {Asset|Link|STACObject|null} [ref] The STAC Asset or Link the request is made for, if available.
    * @return {Promise<*>} The (parsed) response body.
    */
-  async fetch_(url, responseType = 'json') {
-    const response = await fetch(url);
+  async fetch_(url, responseType = 'json', ref = null) {
+    const headers = this.getRequestHeadersFor_(url, ref);
+    const response = await fetch(url, headers ? {headers} : undefined);
     if (!response.ok) {
       throw new Error(`Unexpected response from ${url}: ${response.status}`);
     }
@@ -566,11 +662,18 @@ class STACLayer extends LayerGroup {
      * @type {import("ol/source/ImageStatic.js").Options}
      */
     let options = {
-      url: image.getAbsoluteUrl(),
+      url: this.getRequestUrlFor_(image.getAbsoluteUrl(), image),
       projection,
       imageExtent: toOlExtent(bbox, projection),
       crossOrigin: this.crossOrigin_,
     };
+    const imageLoadFunction = this.createLoadFunction_(
+      createImageLoadFunction,
+      image,
+    );
+    if (imageLoadFunction) {
+      options.imageLoadFunction = imageLoadFunction;
+    }
     if (this.getSourceOptions_) {
       // @ts-ignore
       options = await this.getSourceOptions_(
@@ -599,10 +702,11 @@ class STACLayer extends LayerGroup {
    */
   async addLayerForLink(link) {
     // Replace any occurances of {s} if possible, otherwise return
-    const url = getSpecificWebMapUrl(link);
+    let url = getSpecificWebMapUrl(link);
     if (!url) {
       return;
     }
+    url = this.getRequestUrlFor_(url, link);
 
     const options = {
       attributions:
@@ -611,6 +715,13 @@ class STACLayer extends LayerGroup {
       crossOrigin: this.crossOrigin_,
       url,
     };
+    const tileLoadFunction = this.createLoadFunction_(
+      createTileLoadFunction,
+      link,
+    );
+    if (tileLoadFunction && link.rel !== 'pmtiles') {
+      options.tileLoadFunction = tileLoadFunction;
+    }
 
     const updateOptions = async (type, options) => {
       if (this.getSourceOptions_) {
@@ -621,34 +732,84 @@ class STACLayer extends LayerGroup {
 
     const sources = [];
     switch (link.rel) {
-      case 'pmtiles':
-        const p = new pmtiles.PMTiles(options.url);
-        const headers = await p.getHeader();
-        let source;
-        switch (headers.tileType) {
+      case 'pmtiles': {
+        const snapshot = JSON.stringify(options);
+        /** @type {*} */
+        let pmOptions = await updateOptions(SourceType.PMTiles, options);
+        // Whether getSourceOptions reacted to SourceType.PMTiles,
+        // see the backward compatibility handling below
+        const handled = JSON.stringify(pmOptions) !== snapshot;
+        const headers = this.getRequestHeadersFor_(pmOptions.url, link);
+        const withHeaders = (url) =>
+          headers && typeof url === 'string'
+            ? new pmtiles.FetchSource(url, new Headers(headers))
+            : url;
+        let pmtilesHeader;
+        try {
+          const p = new pmtiles.PMTiles(withHeaders(pmOptions.url));
+          pmtilesHeader = await p.getHeader();
+        } catch (error) {
+          this.handleError_(error);
+          return;
+        }
+        let type;
+        switch (pmtilesHeader.tileType) {
           case pmtiles.TileType.Mvt:
-            source = new PMTilesVectorSource(
-              await updateOptions(SourceType.PMTilesVector, options),
-            );
+            type = SourceType.PMTilesVector;
             break;
           case pmtiles.TileType.Avif:
           case pmtiles.TileType.Jpeg:
           case pmtiles.TileType.Png:
           case pmtiles.TileType.Webp:
-            source = new PMTilesRasterSource(
-              await updateOptions(SourceType.PMTilesRaster, options),
-            );
+            type = SourceType.PMTilesRaster;
             break;
           default:
             return; // Unsupported
         }
+        if (!handled) {
+          // Backward compatibility for getSourceOptions callbacks that don't
+          // handle SourceType.PMTiles yet: call them with the deprecated
+          // type-specific source type once the tile type is known.
+          // As before v1.6.0, these rewrites don't apply to the tile type
+          // sniff above. TODO: Remove in 2.0.0
+          pmOptions = await updateOptions(type, pmOptions);
+        }
+        pmOptions.url = withHeaders(pmOptions.url);
+        const source =
+          type === SourceType.PMTilesVector
+            ? new PMTilesVectorSource(pmOptions)
+            : new PMTilesRasterSource(pmOptions);
         sources.push(source);
         break;
-      case 'tilejson':
-        sources.push(
-          new TileJSON(await updateOptions(SourceType.TileJSON, options)),
-        );
+      }
+      case 'tilejson': {
+        /** @type {*} */
+        const tjOptions = await updateOptions(SourceType.TileJSON, options);
+        if (tjOptions.jsonp || tjOptions.tileJSON) {
+          // Let the source load the manifest itself (e.g. via JSONP)
+          sources.push(new TileJSON(tjOptions));
+          break;
+        }
+        // Load the manifest through the request function so that
+        // credentials are attached
+        let tileJSON;
+        try {
+          tileJSON = await this.fetch_(tjOptions.url, 'json', link);
+        } catch (error) {
+          this.handleError_(error);
+          return;
+        }
+        if (isObject(tileJSON) && Array.isArray(tileJSON.tiles)) {
+          // The tile templates from the manifest must be rewritten as well
+          tileJSON.tiles = tileJSON.tiles.map((template) =>
+            this.getRequestUrlFor_(template, link),
+          );
+        }
+        delete tjOptions.url;
+        tjOptions.tileJSON = tileJSON;
+        sources.push(new TileJSON(tjOptions));
         break;
+      }
       case 'wms':
         if (!Array.isArray(link['wms:layers'])) {
           break;
@@ -685,6 +846,7 @@ class STACLayer extends LayerGroup {
       case 'wmts':
         const wmtsCapabilities = await this.getWmtsCapabilities_(
           url,
+          link,
           link['wmts:encoding'],
         );
         if (!wmtsCapabilities) {
@@ -709,6 +871,10 @@ class STACLayer extends LayerGroup {
           if (opts === null) {
             continue;
           }
+          if (wmtsOptions.tileLoadFunction) {
+            // Not passed through by optionsFromCapabilities
+            opts.tileLoadFunction = wmtsOptions.tileLoadFunction;
+          }
 
           if (typeof link.uriTemplate === 'string') {
             let uriTemplate = link.uriTemplate;
@@ -730,7 +896,7 @@ class STACLayer extends LayerGroup {
               }
             }
             delete opts.urls;
-            opts.url = uriTemplate;
+            opts.url = this.getRequestUrlFor_(uriTemplate, link);
           }
 
           sources.push(new WMTS(opts));
@@ -789,6 +955,7 @@ class STACLayer extends LayerGroup {
     }
 
     const sourceInfo = getGeoTiffSourceInfoFromAsset(asset, this.bands_);
+    sourceInfo.url = this.getRequestUrlFor_(sourceInfo.url, asset);
 
     /**
      * @type {import("ol/source/GeoTIFF.js").Options}
@@ -807,6 +974,11 @@ class STACLayer extends LayerGroup {
     const classificationStyle = getClassificationStyle(asset, sourceInfo.bands);
     if (classificationStyle) {
       options.normalize = false;
+    }
+
+    const headers = this.getRequestHeadersFor_(sourceInfo.url, asset);
+    if (headers) {
+      options.sourceOptions = {headers};
     }
 
     if (this.getSourceOptions_) {
@@ -876,6 +1048,7 @@ class STACLayer extends LayerGroup {
     if (!url) {
       return;
     }
+    url = this.getRequestUrlFor_(url, data);
     /**
      * @type {import("ol/source/XYZ.js").Options}
      */
@@ -883,6 +1056,13 @@ class STACLayer extends LayerGroup {
       crossOrigin: this.crossOrigin_,
       url,
     };
+    const tileLoadFunction = this.createLoadFunction_(
+      createTileLoadFunction,
+      data,
+    );
+    if (tileLoadFunction) {
+      options.tileLoadFunction = tileLoadFunction;
+    }
     if (this.getSourceOptions_) {
       options = await this.getSourceOptions_(SourceType.XYZ, options, data);
     }
@@ -968,7 +1148,11 @@ class STACLayer extends LayerGroup {
    */
   async addGeoJson_(asset) {
     try {
-      const geojson = await this.fetch_(asset.getAbsoluteUrl());
+      const geojson = await this.fetch_(
+        this.getRequestUrlFor_(asset.getAbsoluteUrl(), asset),
+        'json',
+        asset,
+      );
       const layerOptions = await this.updateLayerOptions_(
         LayerType.Vector,
         this.getGeoJsonLayerOptions_(geojson),
@@ -1045,7 +1229,11 @@ class STACLayer extends LayerGroup {
     if (labelAsset && sourceLinks.length > 0) {
       const promises = sourceLinks.map(async (link) => {
         try {
-          const response = await this.fetch_(link.getAbsoluteUrl());
+          const response = await this.fetch_(
+            this.getRequestUrlFor_(link.getAbsoluteUrl(), link),
+            'json',
+            link,
+          );
           const stac = create(response);
           return stac;
         } catch (error) {
@@ -1077,6 +1265,12 @@ class STACLayer extends LayerGroup {
     }
 
     let options = getGeoZarrSourceOptionsFromAsset(asset, this.bands_);
+    options.url = this.getRequestUrlFor_(options.url, asset);
+
+    const headers = this.getRequestHeadersFor_(options.url, asset);
+    if (headers) {
+      options.storeOptions = {headers};
+    }
 
     if (this.getSourceOptions_) {
       // @ts-ignore
@@ -1492,18 +1686,19 @@ class STACLayer extends LayerGroup {
   /**
    * Gets the WMTS capabilities from the given web-map-links URL.
    * @param {string} url Base URL for the WMTS
+   * @param {Link} link The web map link the request is made for.
    * @param {string} [encoding] The request encoding, either `kvp` (default) or `rest`.
    * @return {Promise<Object|null>} Resolves with the WMTS Capabilities object
    * @private
    */
-  async getWmtsCapabilities_(url, encoding = 'kvp') {
+  async getWmtsCapabilities_(url, link, encoding = 'kvp') {
     try {
       const urlObj = new URL(url);
       if (encoding !== 'rest') {
         urlObj.searchParams.set('service', 'wmts');
         urlObj.searchParams.set('request', 'GetCapabilities');
       }
-      const response = await this.fetch_(urlObj.toString(), 'text');
+      const response = await this.fetch_(urlObj.toString(), 'text', link);
       return new WMTSCapabilities().read(response);
     } catch (_) {
       return null;

--- a/src/ol/source/type.js
+++ b/src/ol/source/type.js
@@ -59,14 +59,32 @@ class SourceType {
    */
   static ImageStatic = new SourceType('ImageStatic');
   /**
+   * PMTiles.
+   * Used before the tile type (raster or vector) has been determined,
+   * i.e. `options.url` applies to both raster and vector tiles.
+   * @see {@link https://protomaps.com/docs/pmtiles/}
+   * @api
+   */
+  static PMTiles = new SourceType('PMTiles');
+  /**
    * PMTilesRaster
    * @see {@link https://protomaps.com/docs/pmtiles/}
+   * @deprecated Use {@link SourceType.PMTiles} instead, `getSourceOptions` is
+   * called with it before the tile type is known. For backward compatibility,
+   * callbacks that leave the options unchanged for {@link SourceType.PMTiles}
+   * are still called with this type after the tile type has been determined.
+   * This fallback will be removed in 2.0.0.
    * @api
    */
   static PMTilesRaster = new SourceType('PMTilesRaster');
   /**
    * PMTilesVector
    * @see {@link https://protomaps.com/docs/pmtiles/}
+   * @deprecated Use {@link SourceType.PMTiles} instead, `getSourceOptions` is
+   * called with it before the tile type is known. For backward compatibility,
+   * callbacks that leave the options unchanged for {@link SourceType.PMTiles}
+   * are still called with this type after the tile type has been determined.
+   * This fallback will be removed in 2.0.0.
    * @api
    */
   static PMTilesVector = new SourceType('PMTilesVector');

--- a/test/browser/spec/ol/http.test.js
+++ b/test/browser/spec/ol/http.test.js
@@ -1,0 +1,145 @@
+import {
+  createImageLoadFunction,
+  createTileLoadFunction,
+} from '../../../../src/ol/http.js';
+
+/**
+ * Polls until the given condition is truthy.
+ * @param {function():*} condition The condition to wait for.
+ * @return {Promise} Resolves once the condition is truthy.
+ */
+function waitFor(condition) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (condition()) {
+        resolve();
+      } else if (Date.now() - start > 2000) {
+        reject(new Error('Timeout waiting for condition'));
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+    check();
+  });
+}
+
+describe('ol/http', function () {
+  const SRC = 'https://example.com/image.png';
+  let fetchStub;
+
+  afterEach(function () {
+    if (fetchStub) {
+      fetchStub.restore();
+      fetchStub = null;
+    }
+  });
+
+  describe('createImageLoadFunction', function () {
+    it('assigns the source directly when no headers are returned', function () {
+      fetchStub = sinon.stub(window, 'fetch');
+      const load = createImageLoadFunction(() => null);
+      const img = document.createElement('img');
+      load({getImage: () => img}, SRC);
+      expect(img.src).to.be(SRC);
+      expect(fetchStub.called).to.be(false);
+    });
+
+    it('assigns the source directly when the headers are empty', function () {
+      fetchStub = sinon.stub(window, 'fetch');
+      const load = createImageLoadFunction(() => ({}));
+      const img = document.createElement('img');
+      load({getImage: () => img}, SRC);
+      expect(img.src).to.be(SRC);
+      expect(fetchStub.called).to.be(false);
+    });
+
+    it('fetches with headers and assigns an object URL', async function () {
+      const blob = new Blob(['data'], {type: 'image/png'});
+      fetchStub = sinon
+        .stub(window, 'fetch')
+        .resolves(new Response(blob, {status: 200}));
+      const load = createImageLoadFunction(() => ({
+        Authorization: 'Bearer 123',
+      }));
+      const img = document.createElement('img');
+      load({getImage: () => img}, SRC);
+      await waitFor(() => img.src.startsWith('blob:'));
+      expect(fetchStub.calledOnce).to.be(true);
+      const [url, init] = fetchStub.firstCall.args;
+      expect(url).to.be(SRC);
+      expect(init.headers.Authorization).to.be('Bearer 123');
+    });
+
+    it('revokes the object URL once the image loaded', async function () {
+      const blob = new Blob(['data'], {type: 'image/png'});
+      fetchStub = sinon
+        .stub(window, 'fetch')
+        .resolves(new Response(blob, {status: 200}));
+      const revokeStub = sinon.stub(URL, 'revokeObjectURL');
+      try {
+        const load = createImageLoadFunction(() => ({
+          Authorization: 'Bearer 123',
+        }));
+        const img = document.createElement('img');
+        load({getImage: () => img}, SRC);
+        await waitFor(() => img.src.startsWith('blob:'));
+        const objectUrl = img.src;
+        img.dispatchEvent(new Event('load'));
+        expect(revokeStub.calledWith(objectUrl)).to.be(true);
+      } finally {
+        revokeStub.restore();
+      }
+    });
+
+    it('falls back to the source and reports on request failure', async function () {
+      fetchStub = sinon
+        .stub(window, 'fetch')
+        .resolves(new Response('', {status: 401}));
+      const onError = sinon.spy();
+      const load = createImageLoadFunction(
+        () => ({Authorization: 'Bearer 123'}),
+        onError,
+      );
+      const img = document.createElement('img');
+      load({getImage: () => img}, SRC);
+      await waitFor(() => img.src === SRC);
+      expect(onError.calledOnce).to.be(true);
+      expect(onError.firstCall.args[0]).to.be.an(Error);
+    });
+  });
+
+  describe('createTileLoadFunction', function () {
+    it('assigns the source directly when no headers are returned', function () {
+      fetchStub = sinon.stub(window, 'fetch');
+      const load = createTileLoadFunction(() => null);
+      const img = document.createElement('img');
+      load({getImage: () => img}, SRC);
+      expect(img.src).to.be(SRC);
+      expect(fetchStub.called).to.be(false);
+    });
+
+    it('asks for headers per tile URL', async function () {
+      const blob = new Blob(['data'], {type: 'image/png'});
+      fetchStub = sinon
+        .stub(window, 'fetch')
+        .resolves(new Response(blob, {status: 200}));
+      const getHeaders = sinon.spy((url) =>
+        url.includes('example.com') ? {Authorization: 'Bearer 123'} : null,
+      );
+      const load = createTileLoadFunction(getHeaders);
+
+      const authorized = document.createElement('img');
+      load({getImage: () => authorized}, SRC);
+      await waitFor(() => authorized.src.startsWith('blob:'));
+
+      const external = document.createElement('img');
+      const externalSrc = 'https://other.host/tile.png';
+      load({getImage: () => external}, externalSrc);
+      expect(external.src).to.be(externalSrc);
+
+      expect(getHeaders.calledTwice).to.be(true);
+      expect(fetchStub.calledOnce).to.be(true);
+    });
+  });
+});

--- a/test/browser/spec/ol/layer/STAC.test.js
+++ b/test/browser/spec/ol/layer/STAC.test.js
@@ -2,6 +2,7 @@ import TileLayer from 'ol/layer/Tile.js';
 import XYZ from 'ol/source/XYZ.js';
 import STAC from '../../../../../src/ol/layer/STAC.js';
 import LayerType from '../../../../../src/ol/layer/type.js';
+import SourceType from '../../../../../src/ol/source/type.js';
 
 function getItem() {
   return {
@@ -35,6 +36,79 @@ function getItem() {
     assets: {},
   };
 }
+
+/**
+ * Polls until the given condition is truthy.
+ * @param {function():*} condition The condition to wait for.
+ * @return {Promise} Resolves once the condition is truthy.
+ */
+function waitFor(condition) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (condition()) {
+        resolve();
+      } else if (Date.now() - start > 2000) {
+        reject(new Error('Timeout waiting for condition'));
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+    check();
+  });
+}
+
+/**
+ * Creates a minimal STAC Item.
+ * @param {Object} assets The assets.
+ * @param {Array<Object>} links Additional links.
+ * @return {Object} The STAC Item.
+ */
+function createItem(assets = {}, links = []) {
+  return {
+    type: 'Feature',
+    stac_version: '1.0.0',
+    id: 'test-item',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [0, 1],
+          [1, 1],
+          [1, 0],
+          [0, 0],
+        ],
+      ],
+    },
+    bbox: [0, 0, 1, 1],
+    properties: {
+      datetime: '2024-01-01T00:00:00Z',
+    },
+    links,
+    assets,
+  };
+}
+
+const COG_ASSET = {
+  href: 'https://example.com/asset.tif',
+  type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+  roles: ['visual'],
+};
+
+const THUMBNAIL_ASSET = {
+  href: 'https://example.com/thumb.png',
+  type: 'image/png',
+  roles: ['thumbnail'],
+};
+
+const GEOZARR_ASSET = {
+  href: 'https://example.com/store.zarr/measurements/reflectance',
+  type: 'application/vnd.zarr; version=3; profile=multiscales',
+  roles: ['data'],
+};
+
+const AUTH_HEADERS = {Authorization: 'Bearer 123'};
 
 describe('ol/layer/STAC', function () {
   describe('constructor (defaults)', function () {
@@ -91,6 +165,624 @@ describe('ol/layer/STAC', function () {
       const [layer] = await group.addLayerForLink(link);
 
       expect(layer.getOpacity()).to.be(0.25);
+    });
+  });
+
+  describe('getRequestUrl', function () {
+    let fetchStub;
+    let captured;
+
+    beforeEach(function () {
+      captured = [];
+      fetchStub = sinon
+        .stub(window, 'fetch')
+        .callsFake(() => Promise.resolve(new Response('', {status: 404})));
+    });
+
+    afterEach(function () {
+      fetchStub.restore();
+      fetchStub = null;
+    });
+
+    /**
+     * A getSourceOptions function that captures all calls.
+     * @param {SourceType} type The source type.
+     * @param {Object} options The source options.
+     * @return {Object} The unchanged source options.
+     */
+    function captureSourceOptions(type, options) {
+      captured.push({type, options});
+      return options;
+    }
+
+    /**
+     * Get the captured source options for the given source type.
+     * @param {SourceType} type The source type.
+     * @return {Object|undefined} The source options.
+     */
+    function getCaptured(type) {
+      const entry = captured.find((c) => c.type === type);
+      return entry && entry.options;
+    }
+
+    /**
+     * Appends a token query parameter to the given URL.
+     * @param {Object} ref The STAC Asset or Link.
+     * @param {string} url The URL.
+     * @return {string} The URL with the token appended.
+     */
+    function appendToken(ref, url) {
+      return `${url}${url.includes('?') ? '&' : '?'}token=1`;
+    }
+
+    it('rewrites the GeoTIFF source URLs', async function () {
+      const group = new STAC({
+        data: createItem({cog: COG_ASSET}),
+        getRequestUrl: appendToken,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoTIFF));
+      const options = getCaptured(SourceType.GeoTIFF);
+      expect(options.sources[0].url).to.be(`${COG_ASSET.href}?token=1`);
+    });
+
+    it('rewrites the preview image URL', async function () {
+      const group = new STAC({
+        data: createItem({thumbnail: THUMBNAIL_ASSET}),
+        displayPreview: true,
+        getRequestUrl: appendToken,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.ImageStatic));
+      const options = getCaptured(SourceType.ImageStatic);
+      expect(options.url).to.be(`${THUMBNAIL_ASSET.href}?token=1`);
+    });
+
+    it('rewrites web map link URLs', async function () {
+      const group = new STAC({
+        data: createItem({}, [
+          {
+            rel: 'xyz',
+            href: 'https://example.com/{z}/{x}/{y}.png',
+            type: 'image/png',
+          },
+        ]),
+        displayWebMapLink: true,
+        getRequestUrl: appendToken,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.XYZ));
+      const options = getCaptured(SourceType.XYZ);
+      expect(options.url).to.be('https://example.com/{z}/{x}/{y}.png?token=1');
+    });
+
+    it('rewrites the URL for the default fetch function', async function () {
+      fetchStub.callsFake(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(createItem()), {
+            status: 200,
+            headers: {'Content-Type': 'application/json'},
+          }),
+        ),
+      );
+      const group = new STAC({
+        url: 'https://example.com/item.json',
+        getRequestUrl: appendToken,
+      });
+      group.on('error', () => {});
+      await waitFor(() => fetchStub.called);
+      expect(fetchStub.firstCall.args[0]).to.be(
+        'https://example.com/item.json?token=1',
+      );
+    });
+
+    it('keeps the URLs when null is returned', async function () {
+      const group = new STAC({
+        data: createItem({cog: COG_ASSET}),
+        getRequestUrl: () => null,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoTIFF));
+      const options = getCaptured(SourceType.GeoTIFF);
+      expect(options.sources[0].url).to.be(COG_ASSET.href);
+    });
+
+    it('rewrites the WMTS URI template', async function () {
+      const capabilities = `<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.0.0">
+  <Contents>
+    <Layer>
+      <ows:Title>Test</ows:Title>
+      <ows:Identifier>test</ows:Identifier>
+      <Style isDefault="true"><ows:Identifier>default</ows:Identifier></Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink><TileMatrixSet>matrix</TileMatrixSet></TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="https://example.com/wmts/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>matrix</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789244 20037508.342789244</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>`;
+      fetchStub.callsFake(() =>
+        Promise.resolve(new Response(capabilities, {status: 200})),
+      );
+      const group = new STAC({
+        data: createItem({}, [
+          {
+            rel: 'wmts',
+            href: 'https://example.com/wmts',
+            type: 'application/xml',
+            'wmts:layer': 'test',
+            'wmts:encoding': 'rest',
+            uriTemplate:
+              'https://example.com/tiles/{TileMatrix}/{TileRow}/{TileCol}.png',
+          },
+        ]),
+        displayWebMapLink: true,
+        getRequestUrl: appendToken,
+      });
+      group.on('error', () => {});
+      await waitFor(() =>
+        group
+          .getLayersArray()
+          .some(
+            (layer) =>
+              typeof layer.getSource === 'function' &&
+              layer.getSource() &&
+              typeof layer.getSource().getUrls === 'function' &&
+              (layer.getSource().getUrls() || []).length > 0,
+          ),
+      );
+      const source = group
+        .getLayersArray()
+        .map(
+          (layer) => typeof layer.getSource === 'function' && layer.getSource(),
+        )
+        .find(
+          (s) =>
+            s &&
+            typeof s.getUrls === 'function' &&
+            (s.getUrls() || []).length > 0,
+        );
+      expect(source.getUrls()[0]).to.be(
+        'https://example.com/tiles/{TileMatrix}/{TileRow}/{TileCol}.png?token=1',
+      );
+    });
+  });
+
+  describe('TileJSON manifest', function () {
+    const TILEJSON_LINK = {
+      rel: 'tilejson',
+      href: 'https://example.com/manifest.json',
+      type: 'application/json',
+    };
+    const TILEJSON_DOC = {
+      tilejson: '2.2.0',
+      tiles: ['https://example.com/tiles/{z}/{x}/{y}.png'],
+    };
+
+    let fetchStub;
+
+    beforeEach(function () {
+      fetchStub = sinon.stub(window, 'fetch').callsFake(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(TILEJSON_DOC), {
+            status: 200,
+            headers: {'Content-Type': 'application/json'},
+          }),
+        ),
+      );
+    });
+
+    afterEach(function () {
+      fetchStub.restore();
+      fetchStub = null;
+    });
+
+    it('is fetched through the request function and passed to the source', async function () {
+      const group = new STAC({
+        data: createItem({}, [TILEJSON_LINK]),
+        displayWebMapLink: true,
+      });
+      group.on('error', () => {});
+      await waitFor(() => fetchStub.called);
+      expect(fetchStub.firstCall.args[0]).to.be(TILEJSON_LINK.href);
+      await waitFor(() =>
+        group
+          .getLayersArray()
+          .some(
+            (layer) =>
+              typeof layer.getSource === 'function' &&
+              layer.getSource() &&
+              typeof layer.getSource().getTileJSON === 'function' &&
+              layer.getSource().getTileJSON(),
+          ),
+      );
+    });
+
+    it('carries the configured request headers', async function () {
+      const refs = [];
+      const group = new STAC({
+        data: createItem({}, [TILEJSON_LINK]),
+        displayWebMapLink: true,
+        getRequestHeaders: (ref) => {
+          refs.push(ref);
+          return AUTH_HEADERS;
+        },
+      });
+      group.on('error', () => {});
+      await waitFor(() => fetchStub.called);
+      const init = fetchStub.firstCall.args[1];
+      expect(init.headers).to.eql(AUTH_HEADERS);
+      // The headers callback receives the STAC reference of the request
+      expect(refs.some((ref) => ref && ref.rel === 'tilejson')).to.be(true);
+    });
+
+    it('rewrites the tile templates with getRequestUrl', async function () {
+      const group = new STAC({
+        data: createItem({}, [TILEJSON_LINK]),
+        displayWebMapLink: true,
+        getRequestUrl: (ref, url) =>
+          `${url}${url.includes('?') ? '&' : '?'}token=1`,
+      });
+      group.on('error', () => {});
+      await waitFor(() =>
+        group
+          .getLayersArray()
+          .some(
+            (layer) =>
+              typeof layer.getSource === 'function' &&
+              layer.getSource() &&
+              typeof layer.getSource().getTileJSON === 'function' &&
+              layer.getSource().getTileJSON(),
+          ),
+      );
+      const source = group
+        .getLayersArray()
+        .map(
+          (layer) => typeof layer.getSource === 'function' && layer.getSource(),
+        )
+        .find(
+          (s) => s && typeof s.getTileJSON === 'function' && s.getTileJSON(),
+        );
+      expect(source.getTileJSON().tiles[0]).to.be(
+        'https://example.com/tiles/{z}/{x}/{y}.png?token=1',
+      );
+    });
+  });
+
+  describe('getRequestHeaders', function () {
+    let fetchStub;
+    let captured;
+
+    beforeEach(function () {
+      captured = [];
+      fetchStub = sinon
+        .stub(window, 'fetch')
+        .callsFake(() => Promise.resolve(new Response('', {status: 404})));
+    });
+
+    afterEach(function () {
+      fetchStub.restore();
+      fetchStub = null;
+    });
+
+    /**
+     * A getSourceOptions function that captures all calls.
+     * @param {SourceType} type The source type.
+     * @param {Object} options The source options.
+     * @return {Object} The unchanged source options.
+     */
+    function captureSourceOptions(type, options) {
+      captured.push({type, options});
+      return options;
+    }
+
+    /**
+     * Get the captured source options for the given source type.
+     * @param {SourceType} type The source type.
+     * @return {Object|undefined} The source options.
+     */
+    function getCaptured(type) {
+      const entry = captured.find((c) => c.type === type);
+      return entry && entry.options;
+    }
+
+    it('passes headers to the GeoTIFF source options', async function () {
+      const group = new STAC({
+        data: createItem({cog: COG_ASSET}),
+        getRequestHeaders: () => AUTH_HEADERS,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoTIFF));
+      const options = getCaptured(SourceType.GeoTIFF);
+      expect(options.sourceOptions).to.be.an('object');
+      expect(options.sourceOptions.headers).to.eql(AUTH_HEADERS);
+    });
+
+    it('accepts a plain object for getRequestHeaders', async function () {
+      const group = new STAC({
+        data: createItem({cog: COG_ASSET}),
+        getRequestHeaders: AUTH_HEADERS,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoTIFF));
+      const options = getCaptured(SourceType.GeoTIFF);
+      expect(options.sourceOptions.headers).to.eql(AUTH_HEADERS);
+    });
+
+    it('does not change the GeoTIFF source options by default', async function () {
+      const group = new STAC({
+        data: createItem({cog: COG_ASSET}),
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoTIFF));
+      const options = getCaptured(SourceType.GeoTIFF);
+      expect(options.sourceOptions).to.be(undefined);
+    });
+
+    it('excludes URLs for which no headers are returned', async function () {
+      const group = new STAC({
+        data: createItem({cog: COG_ASSET}),
+        getRequestHeaders: (ref, url) =>
+          url.includes('example.com') ? null : AUTH_HEADERS,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoTIFF));
+      const options = getCaptured(SourceType.GeoTIFF);
+      expect(options.sourceOptions).to.be(undefined);
+    });
+
+    it('passes headers to the GeoZarr store options', async function () {
+      const group = new STAC({
+        data: createItem({zarr: GEOZARR_ASSET}),
+        getRequestHeaders: () => AUTH_HEADERS,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoZarr));
+      const options = getCaptured(SourceType.GeoZarr);
+      expect(options.storeOptions).to.be.an('object');
+      expect(options.storeOptions.headers).to.eql(AUTH_HEADERS);
+    });
+
+    it('does not change the GeoZarr store options by default', async function () {
+      const group = new STAC({
+        data: createItem({zarr: GEOZARR_ASSET}),
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.GeoZarr));
+      const options = getCaptured(SourceType.GeoZarr);
+      expect(options.storeOptions).to.be(undefined);
+    });
+
+    it('sets an imageLoadFunction for preview images', async function () {
+      const group = new STAC({
+        data: createItem({thumbnail: THUMBNAIL_ASSET}),
+        displayPreview: true,
+        getRequestHeaders: () => AUTH_HEADERS,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.ImageStatic));
+      const options = getCaptured(SourceType.ImageStatic);
+      expect(options.imageLoadFunction).to.be.a('function');
+    });
+
+    it('sets no imageLoadFunction by default', async function () {
+      const group = new STAC({
+        data: createItem({thumbnail: THUMBNAIL_ASSET}),
+        displayPreview: true,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.ImageStatic));
+      const options = getCaptured(SourceType.ImageStatic);
+      expect(options.imageLoadFunction).to.be(undefined);
+    });
+
+    it('sets a tileLoadFunction for XYZ web map links', async function () {
+      const group = new STAC({
+        data: createItem({}, [
+          {
+            rel: 'xyz',
+            href: 'https://example.com/{z}/{x}/{y}.png',
+            type: 'image/png',
+          },
+        ]),
+        displayWebMapLink: true,
+        getRequestHeaders: () => AUTH_HEADERS,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.XYZ));
+      const options = getCaptured(SourceType.XYZ);
+      expect(options.tileLoadFunction).to.be.a('function');
+    });
+
+    it('sets no tileLoadFunction by default', async function () {
+      const group = new STAC({
+        data: createItem({}, [
+          {
+            rel: 'xyz',
+            href: 'https://example.com/{z}/{x}/{y}.png',
+            type: 'image/png',
+          },
+        ]),
+        displayWebMapLink: true,
+        getSourceOptions: captureSourceOptions,
+      });
+      group.on('error', () => {});
+      await waitFor(() => getCaptured(SourceType.XYZ));
+      const options = getCaptured(SourceType.XYZ);
+      expect(options.tileLoadFunction).to.be(undefined);
+    });
+
+    it('sends headers with the default fetch function', async function () {
+      fetchStub.callsFake(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(createItem()), {
+            status: 200,
+            headers: {'Content-Type': 'application/json'},
+          }),
+        ),
+      );
+      const group = new STAC({
+        url: 'https://example.com/item.json',
+        getRequestHeaders: () => AUTH_HEADERS,
+      });
+      group.on('error', () => {});
+      await waitFor(() => fetchStub.called);
+      const init = fetchStub.firstCall.args[1];
+      expect(init.headers).to.eql(AUTH_HEADERS);
+    });
+
+    it('sends no headers with the default fetch function by default', async function () {
+      fetchStub.callsFake(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(createItem()), {
+            status: 200,
+            headers: {'Content-Type': 'application/json'},
+          }),
+        ),
+      );
+      const group = new STAC({
+        url: 'https://example.com/item.json',
+      });
+      group.on('error', () => {});
+      await waitFor(() => fetchStub.called);
+      const init = fetchStub.firstCall.args[1];
+      expect(init && init.headers).to.be(undefined);
+    });
+
+    describe('PMTiles', function () {
+      const PMTILES_LINK = {
+        rel: 'pmtiles',
+        href: 'https://example.com/tiles.pmtiles',
+        type: 'application/vnd.pmtiles',
+      };
+
+      it('calls getSourceOptions before the type is sniffed', async function () {
+        const group = new STAC({
+          data: createItem({}, [PMTILES_LINK]),
+          displayWebMapLink: true,
+          getSourceOptions: (type, options) => {
+            captured.push({type, options});
+            if (type === SourceType.PMTiles) {
+              options.url = 'https://rewritten.example/tiles.pmtiles';
+            }
+            return options;
+          },
+        });
+        group.on('error', () => {});
+        await waitFor(() => fetchStub.called);
+        expect(getCaptured(SourceType.PMTiles)).to.be.an('object');
+        const url = fetchStub.firstCall.args[0];
+        expect(url).to.contain('rewritten.example');
+      });
+
+      it('passes headers to the PMTiles requests', async function () {
+        const group = new STAC({
+          data: createItem({}, [PMTILES_LINK]),
+          displayWebMapLink: true,
+          getRequestHeaders: () => AUTH_HEADERS,
+          getSourceOptions: captureSourceOptions,
+        });
+        group.on('error', () => {});
+        await waitFor(() => fetchStub.called);
+        const init = fetchStub.firstCall.args[1];
+        expect(init.headers.get('authorization')).to.be('Bearer 123');
+      });
+
+      /**
+       * Creates the first bytes of a minimal PMTiles v3 archive.
+       * @param {number} tileType The tile type (1 = Mvt, 2 = Png).
+       * @return {Uint8Array} The archive bytes.
+       */
+      function createPmtilesArchive(tileType) {
+        const bytes = new Uint8Array(200);
+        const view = new DataView(bytes.buffer);
+        view.setUint16(0, 19792, true); // magic number 'PM'
+        bytes[7] = 3; // spec version
+        view.setUint32(8, 127, true); // root directory offset
+        view.setUint32(16, 1, true); // root directory length
+        bytes[97] = 1; // internal compression: none
+        bytes[98] = 1; // tile compression: none
+        bytes[99] = tileType;
+        bytes[127] = 0; // root directory: no entries
+        return bytes;
+      }
+
+      /**
+       * Serves a minimal PMTiles archive; the Content-Length header is
+       * required by the PMTiles client for 200 responses.
+       * @param {number} tileType The tile type (1 = Mvt, 2 = Png).
+       * @return {Response} The response.
+       */
+      function pmtilesResponse(tileType) {
+        const bytes = createPmtilesArchive(tileType);
+        return new Response(bytes, {
+          status: 200,
+          headers: {'Content-Length': String(bytes.length)},
+        });
+      }
+
+      // Remove together with SourceType.PMTilesRaster/PMTilesVector in 2.0.0
+      it('still calls getSourceOptions with the deprecated type-specific source type', async function () {
+        fetchStub.callsFake(() => Promise.resolve(pmtilesResponse(2)));
+        const group = new STAC({
+          data: createItem({}, [PMTILES_LINK]),
+          displayWebMapLink: true,
+          // Does not react to SourceType.PMTiles, i.e. a pre-1.6.0 callback
+          getSourceOptions: captureSourceOptions,
+        });
+        group.on('error', () => {});
+        await waitFor(() => getCaptured(SourceType.PMTilesRaster));
+        // The generic source type is passed before the sniff,
+        // the deprecated type-specific one after the sniff
+        expect(captured[0].type).to.be(SourceType.PMTiles);
+        expect(getCaptured(SourceType.PMTilesRaster)).to.be.an('object');
+      });
+
+      it('skips the deprecated call when the callback handles SourceType.PMTiles', async function () {
+        fetchStub.callsFake(() => Promise.resolve(pmtilesResponse(1)));
+        const group = new STAC({
+          data: createItem({}, [PMTILES_LINK]),
+          displayWebMapLink: true,
+          getSourceOptions: (type, options) => {
+            captured.push({type, options});
+            if (type === SourceType.PMTiles) {
+              options.url += '?token=1';
+            }
+            return options;
+          },
+        });
+        group.on('error', () => {});
+        await waitFor(() => group.getLayersArray().length >= 2);
+        expect(getCaptured(SourceType.PMTiles)).to.be.an('object');
+        expect(getCaptured(SourceType.PMTilesVector)).to.be(undefined);
+        expect(getCaptured(SourceType.PMTilesRaster)).to.be(undefined);
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #5 

https://github.com/openlayers/openlayers/pull/17601 enables GeoZarr auth, but needs a new release first. Until then it won't work.